### PR TITLE
Removed the jasperreports.version property from pom.xml. #47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,6 @@
         <com.google.code.maven-license-plugin.version>1.4.0</com.google.code.maven-license-plugin.version>
         <com.h2database.version>1.3.156</com.h2database.version>
         <encoding>UTF-8</encoding>
-        <jasperreports.version>3.5.1</jasperreports.version>
         <java-version>1.7</java-version>
         <javax.servlet.jstl.version>1.2</javax.servlet.jstl.version>
         <junit.version>4.7</junit.version>


### PR DESCRIPTION
Backport to 1.0.x from #55 .
Please review #47 .
