### PR TITLE
[5.0.x] #146: Change to use absolute path as db.basedir at initdb

### DIFF
--- a/projectName-initdb/pom.xml
+++ b/projectName-initdb/pom.xml
@@ -19,7 +19,7 @@
             </activation>
             <properties>
                 <db.encoding>UTF8</db.encoding>
-                <db.basedir>src/main/sqls/postgres</db.basedir>
+                <db.basedir>${project.basedir}/src/main/sqls/postgres</db.basedir>
                 <db.url>jdbc:postgresql://127.0.0.1:5432/projectName</db.url>
                 <db.username>postgres</db.username>
                 <db.password>P0stgres</db.password>


### PR DESCRIPTION
(cherry picked from commit a6b42e2de20c9bdb1e5193e6f339898b9409b0f3)

Please review #146 .