### PR TITLE
Add maven-failsafe-plugin to prevent selenium testing in case of  maven install/package #175

### DIFF
--- a/projectName-selenium/pom.xml
+++ b/projectName-selenium/pom.xml
@@ -11,6 +11,31 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/projectName-selenium/src/test/java/xxxxxx/yyyyyy/zzzzzz/selenium/welcome/HelloIT.java
+++ b/projectName-selenium/src/test/java/xxxxxx/yyyyyy/zzzzzz/selenium/welcome/HelloIT.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "classpath:META-INF/spring/seleniumContext.xml" })
-public class HelloTest {
+public class HelloIT {
 
     @Inject
     WebDriver webDriver;


### PR DESCRIPTION
Please review #175

* `mvn test` -> Normal JUnit tests run (except for `**/*IT.java`)
* `mvn integration-test` -> Selenium tests run (`**/*IT.java`)