### PR TITLE
[1.0.x] add br tag to make the error page size 513 bytes or more #361

### DIFF
--- a/projectName-web/src/main/webapp/WEB-INF/views/common/error/businessError.jsp
+++ b/projectName-web/src/main/webapp/WEB-INF/views/common/error/businessError.jsp
@@ -34,6 +34,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </body>
 </html>

--- a/projectName-web/src/main/webapp/WEB-INF/views/common/error/csrfTokenError.jsp
+++ b/projectName-web/src/main/webapp/WEB-INF/views/common/error/csrfTokenError.jsp
@@ -27,6 +27,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/projectName-web/src/main/webapp/WEB-INF/views/common/error/dataAccessError.jsp
+++ b/projectName-web/src/main/webapp/WEB-INF/views/common/error/dataAccessError.jsp
@@ -28,6 +28,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/projectName-web/src/main/webapp/WEB-INF/views/common/error/resourceNotFoundError.jsp
+++ b/projectName-web/src/main/webapp/WEB-INF/views/common/error/resourceNotFoundError.jsp
@@ -28,6 +28,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/projectName-web/src/main/webapp/WEB-INF/views/common/error/systemError.jsp
+++ b/projectName-web/src/main/webapp/WEB-INF/views/common/error/systemError.jsp
@@ -27,6 +27,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/projectName-web/src/main/webapp/WEB-INF/views/common/error/transactionTokenError.jsp
+++ b/projectName-web/src/main/webapp/WEB-INF/views/common/error/transactionTokenError.jsp
@@ -27,6 +27,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>

--- a/projectName-web/src/main/webapp/WEB-INF/views/common/error/unhandledSystemError.html
+++ b/projectName-web/src/main/webapp/WEB-INF/views/common/error/unhandledSystemError.html
@@ -22,6 +22,16 @@
     <br>
     <br>
     <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     </div>
 </body>
 </html>


### PR DESCRIPTION
(cherry picked from commit c0d55d1e40e78a6517e136697cfffd95cdec4590)

Conflicts:
	projectName-web/src/main/webapp/WEB-INF/views/common/error/accessDeniedError.jsp
	projectName-web/src/main/webapp/WEB-INF/views/common/error/missingCsrfTokenError.jsp

Please review #361 .

This PR is backport for 1.0.x .

Conflicts happened because `accessDeniedError.jsp` and `missingCsrfTokenError.jsp` do not exist in 1.0.x .
