### PR TITLE
remove a definition referring to Sonatype Nexus Snapshots #457 (#458)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,19 +34,6 @@
         <name>TERASOLUNA Framework Team</name>
         <url>http://terasoluna.org</url>
     </organization>
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
(cherry picked from commit f49f933f3c3251ed64bbdc605dbd4685d08e282e)

Please review #457.
