### PR TITLE
Change the groupId of the OracleJDBCDriver #489

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 <!--                 <version>${postgresql.version}</version> -->
 <!--             </dependency> -->
 <!--             <dependency> -->
-<!--                 <groupId>com.oracle.ojdbc</groupId> -->
+<!--                 <groupId>com.oracle.database.jdbc</groupId> -->
 <!--                 <artifactId>ojdbc8</artifactId> -->
 <!--                 <version>${ojdbc.version}</version> -->
 <!--             </dependency> -->

--- a/projectName-domain/pom.xml
+++ b/projectName-domain/pom.xml
@@ -65,7 +65,7 @@
 <!--             <scope>test</scope> -->
 <!--         </dependency> -->
 <!--         <dependency> -->
-<!--             <groupId>com.oracle.ojdbc</groupId> -->
+<!--             <groupId>com.oracle.database.jdbc</groupId> -->
 <!--             <artifactId>ojdbc8</artifactId> -->
 <!--             <scope>test</scope> -->
 <!--         </dependency> -->

--- a/projectName-initdb/pom.xml
+++ b/projectName-initdb/pom.xml
@@ -39,7 +39,7 @@
                 <db.username>oracle</db.username>
                 <db.password>oracle</db.password>
                 <db.driver>oracle.jdbc.driver.OracleDriver</db.driver>
-                <db.groupId>com.oracle.ojdbc</db.groupId>
+                <db.groupId>com.oracle.database.jdbc</db.groupId>
                 <db.artifactId>ojdbc8</db.artifactId>
                 <db.version>${ojdbc.version}</db.version>
                 <db.delimiterType>row</db.delimiterType>

--- a/projectName-selenium/pom.xml
+++ b/projectName-selenium/pom.xml
@@ -56,7 +56,7 @@
 <!--             <scope>test</scope> -->
 <!--         </dependency> -->
 <!--         <dependency> -->
-<!--             <groupId>com.oracle.ojdbc</groupId> -->
+<!--             <groupId>com.oracle.database.jdbc</groupId> -->
 <!--             <artifactId>ojdbc8</artifactId> -->
 <!--             <scope>test</scope> -->
 <!--         </dependency> -->

--- a/projectName-web/pom.xml
+++ b/projectName-web/pom.xml
@@ -125,7 +125,7 @@
 <!--             <scope>runtime</scope> -->
 <!--         </dependency> -->
 <!--         <dependency> -->
-<!--             <groupId>com.oracle.ojdbc</groupId> -->
+<!--             <groupId>com.oracle.database.jdbc</groupId> -->
 <!--             <artifactId>ojdbc8</artifactId> -->
 <!--             <scope>runtime</scope> -->
 <!--         </dependency> -->


### PR DESCRIPTION
Please review #489.

Oracle JDBC Driver's groupId has bean changed from `com.oracle.ojdbc` to `com.oracle.database.jdbc`.