### PR TITLE
update Servlet API, jsp API. #501

### DIFF
--- a/projectName-web/pom.xml
+++ b/projectName-web/pom.xml
@@ -99,14 +99,13 @@
         <!-- == End TERASOLUNA == -->
 
         <!-- == Begin Tomcat == -->
-        <!-- Servlet API 3.0 & JSP API 2.2 -->
+        <!-- Servlet API 4.0 & JSP API 2.3 -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jsp-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
-        <!-- JavaEE/SE APIs -->
         <!--  Required only for Tomcat. If run on other J2EE server,
             remove this dependency and use provided tag libraries. -->
         <dependency>

--- a/projectName-web/src/main/webapp/WEB-INF/web.xml
+++ b/projectName-web/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-    version="3.0">
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_4_0.xsd"
+    version="4.0">
 
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>

--- a/projectName-web/src/main/webapp/WEB-INF/web.xml
+++ b/projectName-web/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-    version="3.1">
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">
 
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>

--- a/projectName-web/src/main/webapp/WEB-INF/web.xml
+++ b/projectName-web/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_4_0.xsd"
-    version="4.0">
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+    version="3.1">
 
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>


### PR DESCRIPTION
Please review #501 .
The only library included in the following section is Apache Taglibs, which is inappropriate because it is an implementation of the JSTL specification.The name of this section itself has been removed as it is not necessary to include it.
> <-- JavaEE/SE APIs -->