### PR TITLE
[5.6.x]Update the version of the maven plugin #514 (#515)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,10 +154,10 @@
     </dependencyManagement>
     <properties>
         <!-- == Maven Plugin Versions == -->
-        <maven-war-plugin.version>2.5</maven-war-plugin.version>
-        <org.codehaus.mojo.build-helper-maven-plugin.version>1.9.1</org.codehaus.mojo.build-helper-maven-plugin.version>
-        <maven-failsafe-plugin.version>2.19</maven-failsafe-plugin.version>
-        <maven-surefire-plugin.version>2.17</maven-surefire-plugin.version>
+        <maven-war-plugin.version>3.3.1</maven-war-plugin.version>
+        <org.codehaus.mojo.build-helper-maven-plugin.version>3.2.0</org.codehaus.mojo.build-helper-maven-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <!-- == Dependency Versions == -->
         <postgresql.version>42.2.9</postgresql.version>
         <ojdbc.version>19.3.0.0</ojdbc.version>


### PR DESCRIPTION
(cherry picked from commit bac84048b6367d70103c959508112aeaf196fd76)

Please review https://github.com/terasolunaorg/terasoluna-gfw-web-multi-blank/issues/516.

Confirmation:

- I did a Grep search for plugin to see if there was any other place that managed the plugin version other than the place where I imported it with cherry-pick.

- Check for new warnings or errors due to upgrading plug-ins.

  - `maven-war-plugin` : Confirmed that war generation succeeds without warning when `mvn package` is executed.

  - `build-helper-maven-plugin` : Confirmed that the source directory is added successfully without any warnings when the project is built.

  - `maven-failsafe-plugin` : Confirmed that the Test Result Report is generated without any warning when the test is executed.

  - `maven-surefire-plugin` : Configured, but not used in the project, so not tested.