### PR TITLE
Added a setting for log output when destroy is executed #522

### DIFF
--- a/projectName-web/src/main/webapp/WEB-INF/web.xml
+++ b/projectName-web/src/main/webapp/WEB-INF/web.xml
@@ -4,6 +4,15 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
     version="3.0">
 
+    <context-param>
+        <param-name>logbackDisableServletContainerInitializer</param-name>
+        <param-value>true</param-value>
+    </context-param>
+
+    <listener>
+        <listener-class>ch.qos.logback.classic.servlet.LogbackServletContextListener</listener-class>
+    </listener>
+
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>

--- a/projectName-web/src/main/webapp/WEB-INF/web.xml
+++ b/projectName-web/src/main/webapp/WEB-INF/web.xml
@@ -4,11 +4,6 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
     version="3.0">
 
-    <context-param>
-        <param-name>logbackDisableServletContainerInitializer</param-name>
-        <param-value>true</param-value>
-    </context-param>
-
     <listener>
         <listener-class>ch.qos.logback.classic.servlet.LogbackServletContextListener</listener-class>
     </listener>
@@ -16,6 +11,16 @@
     <listener>
         <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>
+
+    <listener>
+        <listener-class>org.terasoluna.gfw.web.logging.HttpSessionEventLoggingListener</listener-class>
+    </listener>
+
+    <context-param>
+        <param-name>logbackDisableServletContainerInitializer</param-name>
+        <param-value>true</param-value>
+    </context-param>
+
     <context-param>
         <param-name>contextConfigLocation</param-name>
         <!-- Root ApplicationContext -->
@@ -24,10 +29,6 @@
             classpath*:META-INF/spring/spring-security.xml
         </param-value>
     </context-param>
-
-    <listener>
-        <listener-class>org.terasoluna.gfw.web.logging.HttpSessionEventLoggingListener</listener-class>
-    </listener>
 
     <filter>
         <filter-name>MDCClearFilter</filter-name>


### PR DESCRIPTION
Please review #522 .

Confirmation

Confirmed that the addition of the setting causes the output of the log on destroy, which was not output before the modification.
