### PR TITLE
set source to maven-javadoc-plugin #493

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,13 @@
                         </archive>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <source>${java-version}</source>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Please review #493 

Confirmed that javadoc can be generated by `mvn javadoc:javadoc` using jdk8 and jdk11

Check the following versions for jdk11:
openJDK 11+28
openJDK 11.0.5+10-LTS
