### PR TITLE
fixed deprecated methods #613

### DIFF
--- a/parts/JavaConfig-JSP/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
+++ b/parts/JavaConfig-JSP/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
@@ -41,13 +41,16 @@ public class SpringSecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.formLogin();
-        http.logout();
+        http.formLogin(login -> {
+        });
+        http.logout(logout -> {
+        });
         http.exceptionHandling(ex -> ex
                 .accessDeniedHandler(accessDeniedHandler()));
         http.addFilterAfter(
                 userIdMDCPutFilter(), AnonymousAuthenticationFilter.class);
-        http.sessionManagement();
+        http.sessionManagement(sessionManagement -> {
+        });
 
         return http.build();
     }

--- a/parts/JavaConfig-JSP/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
+++ b/parts/JavaConfig-JSP/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
@@ -1,5 +1,7 @@
 package xxxxxx.yyyyyy.zzzzzz.config.web;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import java.util.LinkedHashMap;
 
 import org.springframework.context.annotation.Bean;
@@ -41,16 +43,13 @@ public class SpringSecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.formLogin(login -> {
-        });
-        http.logout(logout -> {
-        });
+        http.formLogin(login -> withDefaults());
+        http.logout(logout -> withDefaults());
         http.exceptionHandling(ex -> ex
                 .accessDeniedHandler(accessDeniedHandler()));
         http.addFilterAfter(
                 userIdMDCPutFilter(), AnonymousAuthenticationFilter.class);
-        http.sessionManagement(sessionManagement -> {
-        });
+        http.sessionManagement(sessionManagement -> withDefaults());
 
         return http.build();
     }

--- a/parts/JavaConfig-Thymeleaf/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
+++ b/parts/JavaConfig-Thymeleaf/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
@@ -41,13 +41,16 @@ public class SpringSecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.formLogin();
-        http.logout();
+        http.formLogin(login -> {
+        });
+        http.logout(logout -> {
+        });
         http.exceptionHandling(ex -> ex
                 .accessDeniedHandler(accessDeniedHandler()));
         http.addFilterAfter(
                 userIdMDCPutFilter(), AnonymousAuthenticationFilter.class);
-        http.sessionManagement();
+        http.sessionManagement(sessionManagement -> {
+        });
 
         return http.build();
     }

--- a/parts/JavaConfig-Thymeleaf/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
+++ b/parts/JavaConfig-Thymeleaf/projectName-web/src/main/java/xxxxxx/yyyyyy/zzzzzz/config/web/SpringSecurityConfig.java
@@ -1,5 +1,7 @@
 package xxxxxx.yyyyyy.zzzzzz.config.web;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import java.util.LinkedHashMap;
 
 import org.springframework.context.annotation.Bean;
@@ -41,16 +43,13 @@ public class SpringSecurityConfig {
      */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.formLogin(login -> {
-        });
-        http.logout(logout -> {
-        });
+        http.formLogin(login -> withDefaults());
+        http.logout(logout -> withDefaults());
         http.exceptionHandling(ex -> ex
                 .accessDeniedHandler(accessDeniedHandler()));
         http.addFilterAfter(
                 userIdMDCPutFilter(), AnonymousAuthenticationFilter.class);
-        http.sessionManagement(sessionManagement -> {
-        });
+        http.sessionManagement(sessionManagement -> withDefaults());
 
         return http.build();
     }


### PR DESCRIPTION
Please review #613

`HttpSecurity#formLogin()`,`HttpSecurity#logout()`,`HttpSecurity#sessionManagement()` without arguments are now deprecated.
Therefore, empty methods are set as arguments.

https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/web/builders/HttpSecurity.html#formLogin()